### PR TITLE
Fix random crashing when placing and throwing vehicles.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/VehicleConfig.java
+++ b/src/main/java/com/mrcrayfish/vehicle/VehicleConfig.java
@@ -25,6 +25,20 @@ public class VehicleConfig
         @Config.Comment("Configuration options for debugging vehicles")
         @Config.LangKey(Reference.MOD_ID + ".config.client.debug")
         public Debug debug = new Debug();
+
+        @Config.Name("Interaction")
+        @Config.Comment("Configuration options for vehicle interaction")
+        @Config.LangKey(Reference.MOD_ID + ".config.client.interaction")
+        public Interaction interaction = new Interaction();
+    }
+
+    public static class Interaction
+    {
+        @Config.Name("Left-Click Enabled")
+        @Config.Comment("If true, raytraces will be performed on nearby vehicles when left-clicking the mouse, rather than just right-clicking it. "
+                + "This allows one to be damaged/broken when clicking anywhere on it, rather than just on its bounding box.")
+        @Config.LangKey(Reference.MOD_ID + ".config.client.interaction.left_click")
+        public boolean enabledLeftClick = true;
     }
 
     public static class Debug

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
@@ -349,7 +349,7 @@ public class EntityRaytracer
 
     /**
      * Creates part-specific transforms for a raytraceable entity's rendered engine. Arguments passed here should be the same as
-     * those passed to {@link com.mrcrayfish.vehicle.client.render.RenderVehicle#setEnginePosition createTranformListForPart} by the entity's renderer.
+     * those passed to {@link com.mrcrayfish.vehicle.client.render.RenderVehicle#setEnginePosition setEnginePosition} by the entity's renderer.
      * 
      * @param x engine's x position
      * @param y engine's y position

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
@@ -38,6 +38,7 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 import com.google.common.collect.Lists;
@@ -1298,6 +1299,7 @@ public class EntityRaytracer
          * 
          * @return whether or not the click that initiated the hit should be canceled
          */
+        @SideOnly(Side.CLIENT)
         default boolean processHit(RayTraceResultRotated result, boolean rightClick)
         {
             EntityPlayer player = Minecraft.getMinecraft().player;

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
@@ -22,6 +22,7 @@ import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -684,7 +685,7 @@ public class EntityRaytracer
     }
 
     /**
-     * Performs raytrace on interaction boxes and item part triangles of all raytraceable entities within reach of the player upon right-click,
+     * Performs raytrace on interaction boxes and item part triangles of all raytraceable entities within reach of the player upon click,
      * and cancels it if the clicked raytraceable entity returns true from {@link IEntityRaytraceable#processHit processHit}
      * 
      * @param event mouse event
@@ -692,8 +693,8 @@ public class EntityRaytracer
     @SubscribeEvent
     public static void raytraceEntities(MouseEvent event)
     {
-        // Return if the mouse is not being right clicked, if the mouse is being released, or if there are no entity classes to raytrace
-        if (event.getButton() != 1 || !event.isButtonstate() || entityRaytraceSuperclass == null)
+        // Return if not right and/or left clicking, if the mouse is being released, or if there are no entity classes to raytrace
+        if ((event.getButton() != 1 && (!VehicleConfig.CLIENT.interaction.enabledLeftClick || event.getButton() != 0)) || !event.isButtonstate() || entityRaytraceSuperclass == null)
         {
             return;
         }
@@ -746,9 +747,9 @@ public class EntityRaytracer
                 // If not bypassed, process the hit only if it is closer to the player's eyes than what MC thinks the player is looking
                 if (bypass || eyeDistance < hit.distanceTo(eyeVec))
                 {
-                    if (((IEntityRaytraceable) lookObject.entityHit).processHit(lookObject))
+                    if (((IEntityRaytraceable) lookObject.entityHit).processHit(lookObject, event.getButton() == 1))
                     {
-                        // Cancel right-click
+                        // Cancel click
                         event.setCanceled(true);
                     }
                 }
@@ -1293,18 +1294,25 @@ public class EntityRaytracer
          * Default behavior is to perform a general interaction with the entity when a part is clicked.
          * 
          * @param result item part hit - null if none was hit
+         * @param rightClick whether the click was a right-click or a left-click
          * 
-         * @return whether or not the right-click that initiated the hit should be canceled
+         * @return whether or not the click that initiated the hit should be canceled
          */
-        default boolean processHit(RayTraceResultRotated result)
+        default boolean processHit(RayTraceResultRotated result, boolean rightClick)
         {
+            EntityPlayer player = Minecraft.getMinecraft().player;
+            boolean notRiding = player.getRidingEntity() != this;
+            if (!rightClick && notRiding)
+            {
+                Minecraft.getMinecraft().playerController.attackEntity(player, (Entity) this);
+                return true;
+            }
             ItemStack stack = result.getPartHit().getStack();
             if (!stack.isEmpty())
             {
-                boolean notRiding = Minecraft.getMinecraft().player.getRidingEntity() != this;
                 if (notRiding)
                 {
-                    if (Minecraft.getMinecraft().player.isSneaking())
+                    if (player.isSneaking())
                     {
                         PacketHandler.INSTANCE.sendToServer(new MessagePickupVehicle((Entity) this));
                         return true;

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.mrcrayfish.vehicle.entity.vehicle.*;
 import com.mrcrayfish.vehicle.init.ModItems;
+import com.mrcrayfish.vehicle.network.PacketHandler;
+import com.mrcrayfish.vehicle.network.message.MessagePickupVehicle;
 
 /**
  * Author: Phylogeny
@@ -1301,12 +1303,17 @@ public class EntityRaytracer
             ItemStack stack = result.getPartHit().getStack();
             if (!stack.isEmpty())
             {
-                boolean cancel = !Minecraft.getMinecraft().player.isSneaking() && Minecraft.getMinecraft().player.getRidingEntity() != this;
-                if (cancel)
+                boolean notRiding = Minecraft.getMinecraft().player.getRidingEntity() != this;
+                if (notRiding)
                 {
+                    if (Minecraft.getMinecraft().player.isSneaking())
+                    {
+                        PacketHandler.INSTANCE.sendToServer(new MessagePickupVehicle((Entity) this));
+                        return true;
+                    }
                     interactWithEntity(this);
                 }
-                return cancel;
+                return notRiding;
             }
             return false;
         }

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRaytracer.java
@@ -312,7 +312,6 @@ public class EntityRaytracer
             entityRaytracePartsStatic.put(EntityCouch.class, couchParts);
         }
 
-        //TODO debug code (dynamic test code) - delete this code and this comment before release
         //For a dynamic raytrace, all GL operation performed be accounted for
         /* Map<ItemStack, BiFunction<RayTracePart, Entity, Matrix4d>> aluminumBoatPartsDynamic = Maps.<ItemStack, BiFunction<RayTracePart, Entity, Matrix4d>>newHashMap();
         aluminumBoatPartsDynamic.put(new ItemStack(ModItems.ALUMINUM_BOAT_BODY), (part, entity) ->
@@ -907,8 +906,7 @@ public class EntityRaytracer
      */
     public static void renderRaytraceElements(IEntityRaytraceable entity, double x, double y, double z, float yaw)
     {
-        //Debug: set true to render raytrace triangles/boxes
-        if (VehicleConfig.CLIENT.debug.renderOutlines) //TODO keep above comments, but set this to false and delete this comment before release
+        if (VehicleConfig.CLIENT.debug.renderOutlines)
         {
             GlStateManager.pushMatrix();
             {

--- a/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
@@ -1,7 +1,6 @@
 package com.mrcrayfish.vehicle.common;
 
 import com.google.common.collect.ImmutableList;
-import com.mrcrayfish.obfuscate.common.event.EntityLivingInitEvent;
 import com.mrcrayfish.vehicle.Reference;
 import com.mrcrayfish.vehicle.common.entity.HeldVehicleDataHandler;
 import com.mrcrayfish.vehicle.entity.EntityVehicle;
@@ -26,7 +25,6 @@ import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityEntry;
 
@@ -182,8 +180,8 @@ public class CommonEvents
                     Entity entity = EntityList.createEntityFromNBT(tagCompound, world);
                     if(entity != null && entity instanceof EntityVehicle)
                     {
-                        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
-                        if (server.getEntityFromUuid(entity.getUniqueID()) == null)
+                        MinecraftServer server = world.getMinecraftServer();
+                        if (world != null && server.getEntityFromUuid(entity.getUniqueID()) == null)
                         {
                             server.addScheduledTask(() ->
                             {

--- a/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
@@ -171,7 +171,8 @@ public class CommonEvents
             {
                 if(!player.getDataManager().get(HELD_VEHICLE).hasNoTags())
                 {
-                    if(event.getFace() != EnumFacing.UP)
+                    Vec3d clickedVec = event.getHitVec();
+                    if(clickedVec == null || event.getFace() != EnumFacing.UP)
                     {
                         event.setCanceled(true);
                         return;
@@ -199,7 +200,6 @@ public class CommonEvents
                             float rotation = (player.getRotationYawHead() + 90F) % 360.0F;
                             Vec3d heldOffset = ((EntityVehicle) entity).getHeldOffset().rotateYaw((float) Math.toRadians(-player.getRotationYawHead()));
 
-                            Vec3d clickedVec = event.getHitVec();
                             entity.setPositionAndRotation(clickedVec.x + heldOffset.x * 0.0625D, clickedVec.y, clickedVec.z + heldOffset.z * 0.0625D, rotation, 0F);
 
                             //Plays place sound

--- a/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/common/CommonEvents.java
@@ -183,30 +183,33 @@ public class CommonEvents
                     if(entity != null && entity instanceof EntityVehicle)
                     {
                         MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
-                        server.addScheduledTask(() ->
+                        if (server.getEntityFromUuid(entity.getUniqueID()) == null)
                         {
-                            //Updates the DataParameter
-                            NBTTagCompound tag = new NBTTagCompound();
-                            player.getDataManager().set(HELD_VEHICLE, tag);
-
-                            //Updates the player capability
-                            HeldVehicleDataHandler.IHeldVehicle heldVehicle = HeldVehicleDataHandler.getHandler(player);
-                            if(heldVehicle != null)
+                            server.addScheduledTask(() ->
                             {
-                                heldVehicle.setVehicleTag(tag);
-                            }
+                                //Updates the DataParameter
+                                NBTTagCompound tag = new NBTTagCompound();
+                                player.getDataManager().set(HELD_VEHICLE, tag);
 
-                            //Sets the positions and spawns the entity
-                            float rotation = (player.getRotationYawHead() + 90F) % 360.0F;
-                            Vec3d heldOffset = ((EntityVehicle) entity).getHeldOffset().rotateYaw((float) Math.toRadians(-player.getRotationYawHead()));
+                                //Updates the player capability
+                                HeldVehicleDataHandler.IHeldVehicle heldVehicle = HeldVehicleDataHandler.getHandler(player);
+                                if(heldVehicle != null)
+                                {
+                                    heldVehicle.setVehicleTag(tag);
+                                }
 
-                            entity.setPositionAndRotation(clickedVec.x + heldOffset.x * 0.0625D, clickedVec.y, clickedVec.z + heldOffset.z * 0.0625D, rotation, 0F);
+                                //Sets the positions and spawns the entity
+                                float rotation = (player.getRotationYawHead() + 90F) % 360.0F;
+                                Vec3d heldOffset = ((EntityVehicle) entity).getHeldOffset().rotateYaw((float) Math.toRadians(-player.getRotationYawHead()));
 
-                            //Plays place sound
-                            world.spawnEntity(entity);
-                            world.playSound(null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_PLAYER_ATTACK_STRONG, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                        });
-                        event.setCanceled(true);
+                                entity.setPositionAndRotation(clickedVec.x + heldOffset.x * 0.0625D, clickedVec.y, clickedVec.z + heldOffset.z * 0.0625D, rotation, 0F);
+
+                                //Plays place sound
+                                world.spawnEntity(entity);
+                                world.playSound(null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_PLAYER_ATTACK_STRONG, SoundCategory.PLAYERS, 1.0F, 1.0F);
+                            });
+                            event.setCanceled(true);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/mrcrayfish/vehicle/entity/EntitySeaVehicle.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/EntitySeaVehicle.java
@@ -8,8 +8,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
-
 /**
  * Author: MrCrayfish
  */
@@ -123,7 +121,6 @@ public abstract class EntitySeaVehicle extends EntityVehicle
         return inWater;
     }
 
-    @Nullable
     private boolean isUnderWater()
     {
         AxisAlignedBB axisAligned = this.getEntityBoundingBox();

--- a/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntityMoped.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntityMoped.java
@@ -208,20 +208,23 @@ public class EntityMoped extends EntityMotorcycle implements IEntityRaytraceable
 
     @Override
     @SideOnly(Side.CLIENT)
-    public boolean processHit(RayTraceResultRotated result)
+    public boolean processHit(RayTraceResultRotated result, boolean rightClick)
     {
-        RayTracePart partHit = result.getPartHit();
-        if(partHit == CHEST_BOX && this.hasChest())
+        if (rightClick)
         {
-            PacketHandler.INSTANCE.sendToServer(new MessageVehicleChest(this.getEntityId()));
-            return true;
+            RayTracePart partHit = result.getPartHit();
+            if(partHit == CHEST_BOX && this.hasChest())
+            {
+                PacketHandler.INSTANCE.sendToServer(new MessageVehicleChest(this.getEntityId()));
+                return true;
+            }
+            else if(partHit == TRAY_BOX && !this.hasChest())
+            {
+                PacketHandler.INSTANCE.sendToServer(new MessageAttachChest(this.getEntityId()));
+                return true;
+            }
         }
-        else if(partHit == TRAY_BOX && !this.hasChest())
-        {
-            PacketHandler.INSTANCE.sendToServer(new MessageAttachChest(this.getEntityId()));
-            return true;
-        }
-        return IEntityRaytraceable.super.processHit(result);
+        return IEntityRaytraceable.super.processHit(result, rightClick);
     }
 
     @Override

--- a/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntitySportsPlane.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntitySportsPlane.java
@@ -1,21 +1,14 @@
 package com.mrcrayfish.vehicle.entity.vehicle;
 
-import com.mrcrayfish.vehicle.client.EntityRaytracer;
 import com.mrcrayfish.vehicle.client.EntityRaytracer.IEntityRaytraceable;
-import com.mrcrayfish.vehicle.client.EntityRaytracer.RayTraceResultRotated;
 import com.mrcrayfish.vehicle.entity.EntityAirVehicle;
 import com.mrcrayfish.vehicle.init.ModItems;
 import com.mrcrayfish.vehicle.init.ModSounds;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.text.Style;
-import net.minecraft.util.text.TextComponentString;
-import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -150,17 +143,5 @@ public class EntitySportsPlane extends EntityAirVehicle implements IEntityRaytra
     protected float getModifiedAccelerationSpeed()
     {
         return super.getAccelerationSpeed() * (propellerSpeed / 120F);
-    }
-
-    @Override
-    public boolean processHit(RayTraceResultRotated result)//TODO debug method - delete this method and this comment before release
-    {
-        ItemStack stackHit = result.getPartHit().getStack();
-        if (!stackHit.isEmpty() && stackHit.hasTagCompound())
-        {
-            Minecraft.getMinecraft().player.sendMessage(new TextComponentString(stackHit.getTagCompound().getString(EntityRaytracer.PART_NAME)).setStyle(new Style().setColor(TextFormatting.values()[Minecraft.getMinecraft().world.rand.nextInt(15) + 1])));
-            return true;
-        }
-        return IEntityRaytraceable.super.processHit(result);
     }
 }

--- a/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntitySportsPlane.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/vehicle/EntitySportsPlane.java
@@ -155,7 +155,7 @@ public class EntitySportsPlane extends EntityAirVehicle implements IEntityRaytra
     @Override
     public boolean processHit(RayTraceResultRotated result)//TODO debug method - delete this method and this comment before release
     {
-    	ItemStack stackHit = result.getPartHit().getStack();
+        ItemStack stackHit = result.getPartHit().getStack();
         if (!stackHit.isEmpty() && stackHit.hasTagCompound())
         {
             Minecraft.getMinecraft().player.sendMessage(new TextComponentString(stackHit.getTagCompound().getString(EntityRaytracer.PART_NAME)).setStyle(new Style().setColor(TextFormatting.values()[Minecraft.getMinecraft().world.rand.nextInt(15) + 1])));

--- a/src/main/java/com/mrcrayfish/vehicle/network/PacketHandler.java
+++ b/src/main/java/com/mrcrayfish/vehicle/network/PacketHandler.java
@@ -7,28 +7,28 @@ import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 
 public class PacketHandler
 {
-	public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.MOD_ID);
-	private static int messageId = 0;
+    public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.MOD_ID);
+    private static int messageId = 0;
 
-	private static enum Side
+    private static enum Side
     {
         CLIENT, SERVER, BOTH;
     }
 
-	public static void init()
-	{
-		registerMessage(MessageTurn.class, Side.SERVER);
-		registerMessage(MessageAccelerating.class, Side.SERVER);
-		registerMessage(MessageDrift.class, Side.SERVER);
-		registerMessage(MessageHorn.class, Side.SERVER);
-		registerMessage(MessageThrowVehicle.class, Side.SERVER);
-		registerMessage(MessagePickupVehicle.class, Side.SERVER);
-		registerMessage(MessageFlaps.class, Side.SERVER);
-		registerMessage(MessageVehicleChest.class, Side.SERVER);
-		registerMessage(MessageAttachChest.class, Side.SERVER);
-	}
+    public static void init()
+    {
+        registerMessage(MessageTurn.class, Side.SERVER);
+        registerMessage(MessageAccelerating.class, Side.SERVER);
+        registerMessage(MessageDrift.class, Side.SERVER);
+        registerMessage(MessageHorn.class, Side.SERVER);
+        registerMessage(MessageThrowVehicle.class, Side.SERVER);
+        registerMessage(MessagePickupVehicle.class, Side.SERVER);
+        registerMessage(MessageFlaps.class, Side.SERVER);
+        registerMessage(MessageVehicleChest.class, Side.SERVER);
+        registerMessage(MessageAttachChest.class, Side.SERVER);
+    }
 
-	private static void registerMessage(Class packet, Side side)
+    private static void registerMessage(Class packet, Side side)
     {
         if (side != Side.CLIENT)
         {

--- a/src/main/java/com/mrcrayfish/vehicle/network/PacketHandler.java
+++ b/src/main/java/com/mrcrayfish/vehicle/network/PacketHandler.java
@@ -4,21 +4,45 @@ import com.mrcrayfish.vehicle.Reference;
 import com.mrcrayfish.vehicle.network.message.*;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
-import net.minecraftforge.fml.relauncher.Side;
 
 public class PacketHandler
 {
 	public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.MOD_ID);
+	private static int messageId = 0;
+
+	private static enum Side
+    {
+        CLIENT, SERVER, BOTH;
+    }
 
 	public static void init()
 	{
-		INSTANCE.registerMessage(MessageTurn.class, MessageTurn.class, 0, Side.SERVER);
-		INSTANCE.registerMessage(MessageAccelerating.class, MessageAccelerating.class, 1, Side.SERVER);
-		INSTANCE.registerMessage(MessageDrift.class, MessageDrift.class, 2, Side.SERVER);
-		INSTANCE.registerMessage(MessageHorn.class, MessageHorn.class, 3, Side.SERVER);
-		INSTANCE.registerMessage(MessageThrowVehicle.class, MessageThrowVehicle.class, 4, Side.SERVER);
-		INSTANCE.registerMessage(MessageFlaps.class, MessageFlaps.class, 5, Side.SERVER);
-		INSTANCE.registerMessage(MessageVehicleChest.class, MessageVehicleChest.class, 6, Side.SERVER);
-		INSTANCE.registerMessage(MessageAttachChest.class, MessageAttachChest.class, 7, Side.SERVER);
+		registerMessage(MessageTurn.class, Side.SERVER);
+		registerMessage(MessageAccelerating.class, Side.SERVER);
+		registerMessage(MessageDrift.class, Side.SERVER);
+		registerMessage(MessageHorn.class, Side.SERVER);
+		registerMessage(MessageThrowVehicle.class, Side.SERVER);
+		registerMessage(MessagePickupVehicle.class, Side.SERVER);
+		registerMessage(MessageFlaps.class, Side.SERVER);
+		registerMessage(MessageVehicleChest.class, Side.SERVER);
+		registerMessage(MessageAttachChest.class, Side.SERVER);
 	}
+
+	private static void registerMessage(Class packet, Side side)
+    {
+        if (side != Side.CLIENT)
+        {
+            registerMessage(packet, net.minecraftforge.fml.relauncher.Side.SERVER);
+        }
+
+        if (side != Side.SERVER)
+        {
+            registerMessage(packet, net.minecraftforge.fml.relauncher.Side.CLIENT);
+        }
+    }
+
+    private static void registerMessage(Class packet, net.minecraftforge.fml.relauncher.Side side)
+    {
+        INSTANCE.registerMessage(packet, packet, messageId++, side);
+    }
 }

--- a/src/main/java/com/mrcrayfish/vehicle/network/message/MessagePickupVehicle.java
+++ b/src/main/java/com/mrcrayfish/vehicle/network/message/MessagePickupVehicle.java
@@ -1,0 +1,61 @@
+package com.mrcrayfish.vehicle.network.message;
+
+import java.util.UUID;
+
+import com.mrcrayfish.vehicle.common.CommonEvents;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumHand;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+/**
+ * Author: MrCrayfish
+ */
+public class MessagePickupVehicle implements IMessage, IMessageHandler<MessagePickupVehicle, IMessage>
+{
+    private UUID targetEntityID;
+
+    public MessagePickupVehicle() {}
+
+    public MessagePickupVehicle(Entity targetEntity)
+    {
+        targetEntityID = targetEntity.getUniqueID();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf)
+    {
+        ByteBufUtils.writeUTF8String(buf, targetEntityID.toString());
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf)
+    {
+        targetEntityID = UUID.fromString(ByteBufUtils.readUTF8String(buf));
+    }
+
+    @Override
+    public IMessage onMessage(MessagePickupVehicle message, MessageContext ctx)
+    {
+        EntityPlayer player = ctx.getServerHandler().player;
+        MinecraftServer server = player.world.getMinecraftServer();
+        if(server != null && player.isSneaking())
+        {
+            server.addScheduledTask(() ->
+            {
+                Entity targetEntity = server.getEntityFromUuid(message.targetEntityID);
+                if (targetEntity != null)
+                {
+                    CommonEvents.pickUpVehicle(player.world, player, EnumHand.MAIN_HAND, targetEntity);
+                }
+            });
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mrcrayfish/vehicle/network/message/MessageThrowVehicle.java
+++ b/src/main/java/com/mrcrayfish/vehicle/network/message/MessageThrowVehicle.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.Vec3d;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -32,10 +31,10 @@ public class MessageThrowVehicle implements IMessage, IMessageHandler<MessageThr
     public IMessage onMessage(MessageThrowVehicle message, MessageContext ctx)
     {
         EntityPlayer player = ctx.getServerHandler().player;
-        if(player.isSneaking())
+        MinecraftServer server = player.world.getMinecraftServer();
+        if(server != null && player.isSneaking())
         {
             //Spawns the vehicle and plays the placing sound
-            MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
             server.addScheduledTask(() ->
             {
                 if(!player.getDataManager().get(CommonEvents.HELD_VEHICLE).hasNoTags())

--- a/src/main/resources/assets/vehicle/lang/en_us.lang
+++ b/src/main/resources/assets/vehicle/lang/en_us.lang
@@ -10,7 +10,7 @@ tile.traffic_cone.name=Traffic Cone
 
 entity.moped.name=Moped
 
-vehicle.config.title = MrCrayfish's Vehicle Mod Config
+vehicle.config.title=MrCrayfish's Vehicle Mod Config
 vehicle.config.client=Client
 vehicle.config.client.tooltip=Client-only configs
 vehicle.config.client.debug=Debug

--- a/src/main/resources/assets/vehicle/lang/en_us.lang
+++ b/src/main/resources/assets/vehicle/lang/en_us.lang
@@ -17,3 +17,7 @@ vehicle.config.client.debug=Debug
 vehicle.config.client.debug.tooltip=Configuration options for debugging vehicles
 vehicle.config.client.debug.render_outlines=Render Vehicle Outlines
 vehicle.config.client.debug.render_outlines.tooltip=If true, renders an outline of all the elements on a vehicle's model. Useful for debugging interactions.
+vehicle.config.client.interaction=Interaction
+vehicle.config.client.interaction.tooltip=Configuration options for vehicle interaction
+vehicle.config.client.interaction.left_click=Left-Click Enabled
+vehicle.config.client.interaction.left_click.tooltip=If true, raytraces will be performed on nearby vehicles when left-clicking the mouse, rather than just right-clicking it. This allows one to be damaged/broken when clicking anywhere on it, rather than just on its bounding box.


### PR DESCRIPTION
So, I was able to reproduce the crashing upon placing vehicles many times, and even reproduced it once upon throwing one. Well, famous last words, but I believe Ive fixed it. I don't believe tasks scedualed with FML's server instance run on the main thread. In any event, I believe the problem was scheduling a task (where an entity is spawned in the world) there, rather than with the world's server instance. Only time will tell.

Also, I fixed two separate bugs that each caused vehicles to be lost on very rare occasion when picking up and placing them _many_ times in a row very quickly.

Besides that, I fixed a few minor typos/issues, allowed raytraced vehicles to be picked up, and allowed packets to be registered more efficiently and on both sides, while I was at it.