### PR TITLE
Allow fluid pumps to losslessly/evenly distribute fluid to all connected fluid handlers.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/tileentity/TileEntityFluidPump.java
+++ b/src/main/java/com/mrcrayfish/vehicle/tileentity/TileEntityFluidPump.java
@@ -1,5 +1,9 @@
 package com.mrcrayfish.vehicle.tileentity;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
 import com.mrcrayfish.vehicle.block.BlockFluidPipe;
 import com.mrcrayfish.vehicle.block.BlockFluidPump;
 import com.mrcrayfish.vehicle.util.FluidUtils;
@@ -44,20 +48,66 @@ public class TileEntityFluidPump extends TileFluidHandler implements ITickable
             }
         }
 
+        // Collect connections
         state = state.getActualState(world, pos);
+        List<IFluidHandler> fluidHandlers = new ArrayList<>();
         for(EnumFacing face : EnumFacing.VALUES)
         {
             if(state.getValue(BlockFluidPump.CONNECTED_PIPES[face.getIndex()]))
             {
                 tileEntity = world.getTileEntity(pos.offset(face));
-                if(tileEntity != null && tileEntity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, face))
+                if(tileEntity != null)
                 {
                     IFluidHandler handler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, face);
                     if(handler != null)
                     {
-                        FluidUtils.transferFluid(tank, handler, TRANSFER_AMOUNT);
+                        fluidHandlers.add(handler);
                     }
                 }
+            }
+        }
+
+        // Return if no connections, or return and transfer full amount if one connection
+        int count = fluidHandlers.size();
+        if(count <= 1)
+        {
+            if (count == 1)
+            {
+                FluidUtils.transferFluid(tank, fluidHandlers.get(0), TRANSFER_AMOUNT);
+            }
+            return;
+        }
+
+        // Evenly distribute truncated proportion to all connections
+        int remainder = Math.min(tank.getFluidAmount(), TRANSFER_AMOUNT * count);
+        int amount = remainder / count;
+        int filled;
+        if(amount > 0)
+        {
+            ListIterator<IFluidHandler> iterator = fluidHandlers.listIterator();
+            while(iterator.hasNext())
+            {
+                if(FluidUtils.transferFluid(tank, iterator.next(), amount) < amount)
+                {
+                    iterator.remove();
+                }
+            }
+        }
+
+        // Randomly distribute to the remaining non-full connections the proportion that would otherwise be lost in the above truncation
+        remainder %= count;
+        if(fluidHandlers.size() == 1)
+        {
+            FluidUtils.transferFluid(tank, fluidHandlers.get(0), remainder);
+        }
+        for(int i = 0; i < remainder && !fluidHandlers.isEmpty(); i++)
+        {
+            int index = world.rand.nextInt(fluidHandlers.size());
+            filled = FluidUtils.transferFluid(tank, fluidHandlers.get(index), 1);
+            remainder -= filled;
+            if(filled == 0)
+            {
+                fluidHandlers.remove(index);
             }
         }
     }

--- a/src/main/java/com/mrcrayfish/vehicle/util/FluidUtils.java
+++ b/src/main/java/com/mrcrayfish/vehicle/util/FluidUtils.java
@@ -20,7 +20,7 @@ import org.lwjgl.opengl.GL11;
  */
 public class FluidUtils
 {
-    public static boolean transferFluid(IFluidHandler source, IFluidHandler target, int maxAmount)
+    public static int transferFluid(IFluidHandler source, IFluidHandler target, int maxAmount)
     {
         FluidStack drained = source.drain(maxAmount, false);
         if(drained != null && drained.amount > 0)
@@ -29,11 +29,10 @@ public class FluidUtils
             if(filled > 0)
             {
                 drained = source.drain(filled, true);
-                target.fill(drained, true);
-                return true;
+                return target.fill(drained, true);
             }
         }
-        return false;
+        return 0;
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Currently, each tick, the pump takes 10mB from its source and attempts to push 10mB to each connection. This causes it to completely fill one connection before moving on the the next when a 10mB pass-through is maintained, yet fill all connections evenly if the pump has a fluid surplus.

This PR allows either 10mB to be pushed to all connections each tick, if there is a surplus, yet evenly distribute the contents of the tank to each connection if there is not. To avoid fluid loss due to integer division, the remaining 1-5mB is randomly distributed to all remaining non-full connections, as I believe it is very important that fluid be conserved.