### PR TITLE
Remove unsupported sound json file entries and optimize sound registration.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/init/ModSounds.java
+++ b/src/main/java/com/mrcrayfish/vehicle/init/ModSounds.java
@@ -1,5 +1,7 @@
 package com.mrcrayfish.vehicle.init;
 
+import com.mrcrayfish.vehicle.Reference;
+
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 
@@ -38,37 +40,38 @@ public class ModSounds
 
     public static void register()
     {
-        hornMono = registerSound("vehicle:horn_mono");
-        hornStereo = registerSound("vehicle:horn_stereo");
-        atvEngineMono = registerSound("vehicle:atv_engine_mono");
-        atvEngineStereo = registerSound("vehicle:atv_engine_stereo");
-        goKartEngineMono = registerSound("vehicle:go_kart_engine_mono");
-        goKartEngineStereo = registerSound("vehicle:go_kart_engine_stereo");
-        electricEngineMono = registerSound("vehicle:electric_engine_mono");
-        electricEngineStereo = registerSound("vehicle:electric_engine_stereo");
-        bonk = registerSound("vehicle:bonk");
-        pickUpVehicle = registerSound("vehicle:pick_up_vehicle");
-        speedBoatEngineMono = registerSound("vehicle:speed_boat_engine_mono");
-        speedBoatEngineStereo = registerSound("vehicle:speed_boat_engine_stereo");
-        sprayCanSpray = registerSound("vehicle:spray_can_spray");
-        sprayCanShake = registerSound("vehicle:spray_can_shake");
-        mopedEngineMono = registerSound("vehicle:moped_engine_mono");
-        mopedEngineStereo = registerSound("vehicle:moped_engine_stereo");
-        sportsPlaneEngineMono = registerSound("vehicle:sports_plane_engine_mono");
-        sportsPlaneEngineStereo = registerSound("vehicle:sports_plane_engine_stereo");
-        boostPad = registerSound("vehicle:boost_pad");
-        liquidGlug = registerSound("vehicle:liquid_glug");
-        fuelPortOpen = registerSound("vehicle:fuel_port_open");
-        fuelPortClose = registerSound("vehicle:fuel_port_close");
-        fuelPort2Open = registerSound("vehicle:fuel_port_2_open");
-        fuelPort2Close = registerSound("vehicle:fuel_port_2_close");
-        vehicleCratePanelLand = registerSound("vehicle:vehicle_crate_panel_land");
-        jackUp = registerSound("vehicle:jack_up");
-        jackDown = registerSound("vehicle:jack_down");
+        hornMono = registerSound("horn_mono");
+        hornStereo = registerSound("horn_stereo");
+        atvEngineMono = registerSound("atv_engine_mono");
+        atvEngineStereo = registerSound("atv_engine_stereo");
+        goKartEngineMono = registerSound("go_kart_engine_mono");
+        goKartEngineStereo = registerSound("go_kart_engine_stereo");
+        electricEngineMono = registerSound("electric_engine_mono");
+        electricEngineStereo = registerSound("electric_engine_stereo");
+        bonk = registerSound("bonk");
+        pickUpVehicle = registerSound("pick_up_vehicle");
+        speedBoatEngineMono = registerSound("speed_boat_engine_mono");
+        speedBoatEngineStereo = registerSound("speed_boat_engine_stereo");
+        sprayCanSpray = registerSound("spray_can_spray");
+        sprayCanShake = registerSound("spray_can_shake");
+        mopedEngineMono = registerSound("moped_engine_mono");
+        mopedEngineStereo = registerSound("moped_engine_stereo");
+        sportsPlaneEngineMono = registerSound("sports_plane_engine_mono");
+        sportsPlaneEngineStereo = registerSound("sports_plane_engine_stereo");
+        boostPad = registerSound("boost_pad");
+        liquidGlug = registerSound("liquid_glug");
+        fuelPortOpen = registerSound("fuel_port_open");
+        fuelPortClose = registerSound("fuel_port_close");
+        fuelPort2Open = registerSound("fuel_port_2_open");
+        fuelPort2Close = registerSound("fuel_port_2_close");
+        vehicleCratePanelLand = registerSound("vehicle_crate_panel_land");
+        jackUp = registerSound("jack_up");
+        jackDown = registerSound("jack_down");
     }
 
     private static SoundEvent registerSound(String soundNameIn)
     {
+        soundNameIn = Reference.MOD_ID + ":" + soundNameIn;
         ResourceLocation resource = new ResourceLocation(soundNameIn);
         SoundEvent sound = new SoundEvent(resource).setRegistryName(soundNameIn);
         RegistrationHandler.Sounds.register(sound);

--- a/src/main/resources/assets/vehicle/sounds.json
+++ b/src/main/resources/assets/vehicle/sounds.json
@@ -1,110 +1,83 @@
 {
     "horn_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:horn_mono"}]
     },
     "horn_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:horn_stereo"}]
     },
     "atv_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:atv_engine_mono"}]
     },
     "atv_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:atv_engine_stereo"}]
     },
     "go_kart_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:go_kart_engine_mono"}]
     },
     "go_kart_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:go_kart_engine_stereo"}]
     },
     "electric_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:electric_engine_mono"}]
     },
     "electric_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:electric_engine_stereo"}]
     },
     "bonk": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:bonk"}]
     },
     "pick_up_vehicle": {
-        "category": "player",
         "sounds": [ {"name": "vehicle:pick_up_vehicle"}]
     },
     "speed_boat_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:speed_boat_engine_mono"}]
     },
     "speed_boat_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:speed_boat_engine_stereo"}]
     },
     "spray_can_spray": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:spray_can_spray"}]
     },
     "spray_can_shake": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:spray_can_shake"}]
     },
     "moped_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:moped_engine_mono"}]
     },
     "moped_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:moped_engine_stereo"}]
     },
     "sports_plane_engine_mono": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:sports_plane_engine_mono"}]
     },
     "sports_plane_engine_stereo": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:sports_plane_engine_stereo"}]
     },
     "boost_pad": {
-        "category": "block",
         "sounds": [ {"name": "vehicle:boost_pad"}]
     },
     "liquid_glug": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:liquid_glug"}]
     },
     "fuel_port_open": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:fuel_port_open"}]
     },
     "fuel_port_close": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:fuel_port_close"}]
     },
     "fuel_port_2_open": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:fuel_port_2_open"}]
     },
     "fuel_port_2_close": {
-        "category": "ambient",
         "sounds": [ {"name": "vehicle:fuel_port_2_close"}]
     },
     "vehicle_crate_panel_land": {
-        "category": "block",
         "sounds": [ {"name": "vehicle:vehicle_crate_panel_land"}]
     },
     "jack_up": {
-        "category": "block",
         "sounds": [ {"name": "vehicle:jack_up"}]
     },
     "jack_down": {
-        "category": "block",
         "sounds": [ {"name": "vehicle:jack_down"}]
     }
 }


### PR DESCRIPTION
As of MC 1.10, 'category' is not a supported entry in the sounds json file. The category must always be specified in-code when playing sounds.