### PR TITLE
Allow reloading resources with F3-T to clear and re-register the EntityRaytracer.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
@@ -670,6 +670,7 @@ public class ClientEvents
     public void clearCaches(TextureStitchEvent.Post event)
     {
         FluidUtils.clearCacheFluidColor();
+        EntityRaytracer.clearDataForReregistration();
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This also moves initial registration to after item models are in place, allowing `RayTracePart`s to initialize with isolated item models rather than items themselves, as is planned for future vehicle rendering.