### PR TITLE
Resorted entity interaction and submerged fog rendering for mod fluids.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
@@ -1,6 +1,8 @@
 package com.mrcrayfish.vehicle.client;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mrcrayfish.obfuscate.client.event.PlayerModelEvent;
 import com.mrcrayfish.obfuscate.client.event.RenderItemEvent;
 import com.mrcrayfish.obfuscate.common.data.SyncedPlayerData;
@@ -14,6 +16,7 @@ import com.mrcrayfish.vehicle.entity.LandVehicleEntity;
 import com.mrcrayfish.vehicle.entity.PoweredVehicleEntity;
 import com.mrcrayfish.vehicle.entity.VehicleEntity;
 import com.mrcrayfish.vehicle.entity.VehicleProperties;
+import com.mrcrayfish.vehicle.fluid.ModFluid;
 import com.mrcrayfish.vehicle.init.ModDataKeys;
 import com.mrcrayfish.vehicle.init.ModSounds;
 import com.mrcrayfish.vehicle.item.SprayCanItem;
@@ -33,6 +36,7 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import net.minecraft.util.HandSide;
@@ -583,15 +587,26 @@ public class ClientEvents
     @SubscribeEvent
     public void setLiquidFogDensity(EntityViewRenderEvent.FogDensity event)
     {
-        event.getInfo().getBlockAtCamera();
-        /*Block block = event.getState().getBlock(); //TODO do i need to fix this
-        boolean isSap = block == ModBlocks.ENDER_SAP.get();
-        if (isSap || block == ModBlocks.FUELIUM.get() || block == ModBlocks.BLAZE_JUICE.get())
+        Fluid fluid = event.getInfo().getFluidState().getFluid();
+        if(fluid instanceof ModFluid)
         {
-            GlStateManager.setFog(GlStateManager.FogMode.EXP);
-            event.setDensity(isSap ? 1 : 0.5F);
+            RenderSystem.fogMode(GlStateManager.FogMode.EXP);
+            event.setDensity(((ModFluid) fluid).getFogDensity());
             event.setCanceled(true);
-        }*/
+        }
+    }
+
+    @SubscribeEvent
+    public void setLiquidFogColor(EntityViewRenderEvent.FogColors event)
+    {
+        Fluid fluid = event.getInfo().getFluidState().getFluid();
+        if(fluid instanceof ModFluid)
+        {
+            ModFluid modFluid = (ModFluid) fluid;
+            event.setRed(modFluid.getFogRed());
+            event.setGreen(modFluid.getFogGreen());
+            event.setBlue(modFluid.getFogBlue());
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/ClientEvents.java
@@ -53,6 +53,7 @@ import org.lwjgl.glfw.GLFW;
 
 import java.awt.*;
 import java.text.DecimalFormat;
+import java.util.function.Consumer;
 
 /**
  * Author: MrCrayfish
@@ -587,25 +588,31 @@ public class ClientEvents
     @SubscribeEvent
     public void setLiquidFogDensity(EntityViewRenderEvent.FogDensity event)
     {
-        Fluid fluid = event.getInfo().getFluidState().getFluid();
-        if(fluid instanceof ModFluid)
+        alterFog(event, fluid ->
         {
             RenderSystem.fogMode(GlStateManager.FogMode.EXP);
-            event.setDensity(((ModFluid) fluid).getFogDensity());
+            event.setDensity(fluid.getFogDensity());
             event.setCanceled(true);
-        }
+        });
     }
 
     @SubscribeEvent
     public void setLiquidFogColor(EntityViewRenderEvent.FogColors event)
     {
+        alterFog(event, fluid ->
+        {
+            event.setRed(fluid.getFogRed());
+            event.setGreen(fluid.getFogGreen());
+            event.setBlue(fluid.getFogBlue());
+        });
+    }
+
+    private void alterFog(EntityViewRenderEvent event, Consumer<ModFluid> action)
+    {
         Fluid fluid = event.getInfo().getFluidState().getFluid();
         if(fluid instanceof ModFluid)
         {
-            ModFluid modFluid = (ModFluid) fluid;
-            event.setRed(modFluid.getFogRed());
-            event.setGreen(modFluid.getFogGreen());
-            event.setBlue(modFluid.getFogBlue());
+            action.accept((ModFluid) fluid);
         }
     }
 

--- a/src/main/java/com/mrcrayfish/vehicle/fluid/BlazeJuice.java
+++ b/src/main/java/com/mrcrayfish/vehicle/fluid/BlazeJuice.java
@@ -1,6 +1,5 @@
 package com.mrcrayfish.vehicle.fluid;
 
-import com.mrcrayfish.vehicle.Reference;
 import com.mrcrayfish.vehicle.init.ModBlocks;
 import com.mrcrayfish.vehicle.init.ModFluids;
 import com.mrcrayfish.vehicle.init.ModItems;
@@ -8,19 +7,15 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.Item;
 import net.minecraft.state.StateContainer;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvents;
-import net.minecraftforge.fluids.FluidAttributes;
-import net.minecraftforge.fluids.ForgeFlowingFluid;
 
 /**
  * Author: MrCrayfish
  */
-public abstract class BlazeJuice extends ForgeFlowingFluid
+public abstract class BlazeJuice extends ModFluid
 {
     public BlazeJuice()
     {
-        super(new Properties(() -> ModFluids.BLAZE_JUICE.get(), () -> ModFluids.FLOWING_BLAZE_JUICE.get(), FluidAttributes.builder(new ResourceLocation(Reference.MOD_ID, "block/blaze_juice_still"), new ResourceLocation(Reference.MOD_ID, "block/blaze_juice_flowing")).viscosity(800).sound(SoundEvents.ITEM_BUCKET_FILL, SoundEvents.ITEM_BUCKET_EMPTY)).block(() -> ModBlocks.BLAZE_JUICE.get()));
+        super(ModFluids.BLAZE_JUICE, ModFluids.FLOWING_BLAZE_JUICE, ModBlocks.BLAZE_JUICE, 1000, 800, 0.5F, 254, 198, 0);
     }
 
     @Override
@@ -38,7 +33,7 @@ public abstract class BlazeJuice extends ForgeFlowingFluid
         }
 
         @Override
-        public int getLevel(IFluidState p_207192_1_)
+        public int getLevel(IFluidState state)
         {
             return 8;
         }

--- a/src/main/java/com/mrcrayfish/vehicle/fluid/EnderSap.java
+++ b/src/main/java/com/mrcrayfish/vehicle/fluid/EnderSap.java
@@ -1,6 +1,5 @@
 package com.mrcrayfish.vehicle.fluid;
 
-import com.mrcrayfish.vehicle.Reference;
 import com.mrcrayfish.vehicle.init.ModBlocks;
 import com.mrcrayfish.vehicle.init.ModFluids;
 import com.mrcrayfish.vehicle.init.ModItems;
@@ -8,19 +7,15 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.Item;
 import net.minecraft.state.StateContainer;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvents;
-import net.minecraftforge.fluids.FluidAttributes;
-import net.minecraftforge.fluids.ForgeFlowingFluid;
 
 /**
  * Author: MrCrayfish
  */
-public abstract class EnderSap extends ForgeFlowingFluid
+public abstract class EnderSap extends ModFluid
 {
     public EnderSap()
     {
-        super(new Properties(() -> ModFluids.ENDER_SAP.get(), () -> ModFluids.FLOWING_ENDER_SAP.get(), FluidAttributes.builder(new ResourceLocation(Reference.MOD_ID, "block/ender_sap_still"), new ResourceLocation(Reference.MOD_ID, "block/ender_sap_flowing")).viscosity(3000).sound(SoundEvents.ITEM_BUCKET_FILL, SoundEvents.ITEM_BUCKET_EMPTY)).block(() -> ModBlocks.ENDER_SAP.get()));
+        super(ModFluids.ENDER_SAP, ModFluids.FLOWING_ENDER_SAP, ModBlocks.ENDER_SAP, 1000, 3000, 1F, 10, 93, 80);
     }
 
     @Override
@@ -38,7 +33,7 @@ public abstract class EnderSap extends ForgeFlowingFluid
         }
 
         @Override
-        public int getLevel(IFluidState p_207192_1_)
+        public int getLevel(IFluidState state)
         {
             return 8;
         }

--- a/src/main/java/com/mrcrayfish/vehicle/fluid/Fuelium.java
+++ b/src/main/java/com/mrcrayfish/vehicle/fluid/Fuelium.java
@@ -1,6 +1,5 @@
 package com.mrcrayfish.vehicle.fluid;
 
-import com.mrcrayfish.vehicle.Reference;
 import com.mrcrayfish.vehicle.init.ModBlocks;
 import com.mrcrayfish.vehicle.init.ModFluids;
 import com.mrcrayfish.vehicle.init.ModItems;
@@ -8,19 +7,15 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.Item;
 import net.minecraft.state.StateContainer;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvents;
-import net.minecraftforge.fluids.FluidAttributes;
-import net.minecraftforge.fluids.ForgeFlowingFluid;
 
 /**
  * Author: MrCrayfish
  */
-public abstract class Fuelium extends ForgeFlowingFluid
+public abstract class Fuelium extends ModFluid
 {
     public Fuelium()
     {
-        super(new Properties(() -> ModFluids.FUELIUM.get(), () -> ModFluids.FLOWING_FUELIUM.get(), FluidAttributes.builder(new ResourceLocation(Reference.MOD_ID, "block/fuelium_still"), new ResourceLocation(Reference.MOD_ID, "block/fuelium_flowing")).sound(SoundEvents.ITEM_BUCKET_FILL, SoundEvents.ITEM_BUCKET_EMPTY).density(900).viscosity(900)).block(() -> ModBlocks.FUELIUM.get()));
+        super(ModFluids.FUELIUM, ModFluids.FLOWING_FUELIUM, ModBlocks.FUELIUM, 900, 900, 0.5F, 148, 242, 45);
     }
 
     @Override
@@ -38,7 +33,7 @@ public abstract class Fuelium extends ForgeFlowingFluid
         }
 
         @Override
-        public int getLevel(IFluidState p_207192_1_)
+        public int getLevel(IFluidState state)
         {
             return 8;
         }

--- a/src/main/java/com/mrcrayfish/vehicle/fluid/ModFluid.java
+++ b/src/main/java/com/mrcrayfish/vehicle/fluid/ModFluid.java
@@ -1,0 +1,57 @@
+package com.mrcrayfish.vehicle.fluid;
+
+import com.mrcrayfish.vehicle.Reference;
+import net.minecraft.block.FlowingFluidBlock;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvents;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+import net.minecraftforge.fml.RegistryObject;
+
+import java.util.function.Supplier;
+
+public abstract class ModFluid extends ForgeFlowingFluid
+{
+    private final float fogDensity, fogRed, fogGreen, fogBlue;
+
+    protected ModFluid(Supplier<? extends Fluid> still, Supplier<? extends Fluid> flowing, RegistryObject<FlowingFluidBlock> block,
+                       int density, int viscosity, float fogDensity, int fogRed, int fogGreen, int fogBlue)
+    {
+        super(new Properties(still, flowing,
+                FluidAttributes.builder(getTexture(block, "_still"), getTexture(block, "_flowing"))
+                        .density(density).viscosity(viscosity)
+                        .sound(SoundEvents.ITEM_BUCKET_FILL, SoundEvents.ITEM_BUCKET_EMPTY))
+                .block(block));
+
+        this.fogDensity = fogDensity;
+        this.fogRed = fogRed / 255F;
+        this.fogGreen = fogGreen / 255F;
+        this.fogBlue = fogBlue / 255F;
+    }
+
+    private static ResourceLocation getTexture(RegistryObject<FlowingFluidBlock> block, String suffix)
+    {
+        return new ResourceLocation(Reference.MOD_ID, "block/" + block.getId().getPath() + suffix);
+    }
+
+    public float getFogDensity()
+    {
+        return fogDensity;
+    }
+
+    public float getFogRed()
+    {
+        return fogRed;
+    }
+
+    public float getFogGreen()
+    {
+        return fogGreen;
+    }
+
+    public float getFogBlue()
+    {
+        return fogBlue;
+    }
+}

--- a/src/main/resources/data/minecraft/tags/fluids/water.json
+++ b/src/main/resources/data/minecraft/tags/fluids/water.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "vehicle:blaze_juice",
+    "vehicle:flowing_blaze_juice",
+    "vehicle:ender_sap",
+    "vehicle:flowing_ender_sap",
+    "vehicle:fuelium",
+    "vehicle:flowing_fuelium"
+  ]
+}


### PR DESCRIPTION
Currently, mod fluids don't interact with entities at all, and render a dense white fog when they're submerged in them.