### PR TITLE
Fix for seeder not pulling seeds from storage trailers in front of it

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/entity/trailer/SeederTrailerEntity.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/trailer/SeederTrailerEntity.java
@@ -159,7 +159,7 @@ public class SeederTrailerEntity extends TrailerEntity implements IStorage
             for(int i = 0; i < storage.getSizeInventory(); i++)
             {
                 ItemStack stack = storage.getStackInSlot(i);
-                if(!stack.isEmpty() && stack.getItem() instanceof net.minecraftforge.common.IPlantable)
+                if(!stack.isEmpty() && this.isSeed(stack))
                 {
                     return stack;
                 }


### PR DESCRIPTION
Hi @MrCrayfish 

I found this issue in Minecraft 1.16.3 with the following configuration: Tractor -> Storage Trailer -> Storage Trailer -> Seeder. The issue was that when the Seeder was empty, it was not pulling existing seeds from the storage trailers in front of it.

I've tested locally and it seems to be working fine.
