### PR TITLE
[1.16.X] Fixed seeder not accepting potatoes and carrots and not pulling seeds from storage trailers.

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/entity/trailer/SeederTrailerEntity.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/trailer/SeederTrailerEntity.java
@@ -34,7 +34,6 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.network.NetworkHooks;
@@ -159,7 +158,7 @@ public class SeederTrailerEntity extends TrailerEntity implements IStorage
             for(int i = 0; i < storage.getSizeInventory(); i++)
             {
                 ItemStack stack = storage.getStackInSlot(i);
-                if(!stack.isEmpty() && stack.getItem() instanceof net.minecraftforge.common.IPlantable)
+                if(!stack.isEmpty() && this.isSeed(stack))
                 {
                     return stack;
                 }
@@ -275,7 +274,8 @@ public class SeederTrailerEntity extends TrailerEntity implements IStorage
     @Override
     public boolean isStorageItem(ItemStack stack)
     {
-        return !stack.isEmpty() && stack.getItem().isIn(Tags.Items.SEEDS);
+
+        return !stack.isEmpty() && stack.getItem() instanceof BlockNamedItem && ((BlockNamedItem) stack.getItem()).getBlock() instanceof CropsBlock;
     }
 
     @Override


### PR DESCRIPTION
Fixed seeder not accepting potatoes and carrots. #308 
The fix for seeder not pulling seeds from storage trailers is also included. (credit for this goes to #378 )
Unused import statements have also been removed.

Issue #308 also applies to the versions of the mod for MC 1.14.X and 1.15.X.
