### PR TITLE
Fix trailers friction and make them slowdown gracefully

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/entity/TrailerEntity.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/TrailerEntity.java
@@ -100,7 +100,7 @@ public abstract class TrailerEntity extends VehicleEntity
         else if(!world.isRemote)
         {
             motion = this.getMotion();
-            this.setMotion(0, 0, 0);
+            this.setMotion(this.getMotion().mul(0.8, 0.98, 0.8));
             this.move(MoverType.SELF, this.getMotion());
         }
 

--- a/src/main/java/com/mrcrayfish/vehicle/entity/TrailerEntity.java
+++ b/src/main/java/com/mrcrayfish/vehicle/entity/TrailerEntity.java
@@ -100,7 +100,8 @@ public abstract class TrailerEntity extends VehicleEntity
         else if(!world.isRemote)
         {
             motion = this.getMotion();
-            this.move(MoverType.SELF, new Vector3d(motion.getX() * 0.75, motion.getY(), motion.getZ() * 0.75));
+            this.setMotion(0, 0, 0);
+            this.move(MoverType.SELF, this.getMotion());
         }
 
         this.doBlockCollisions();


### PR DESCRIPTION
This commit fix an issue reported multiple times such as 

https://github.com/MrCrayfish/MrCrayfishVehicleMod/issues/450
https://github.com/MrCrayfish/MrCrayfishVehicleMod/issues/448

I tested this change in 1.16.5. I had to use a commit from a few days ago as the very latest from 1.16.X crashes my game and am not sure why as of yet.

Disclaimer: first time ever I try to code on a Minecraft mod, hopefully I've done nothing completely dumb :)