### PR TITLE
[1.16.X] Crash Fix

### DIFF
--- a/src/main/java/com/mrcrayfish/vehicle/block/VehicleCrateBlock.java
+++ b/src/main/java/com/mrcrayfish/vehicle/block/VehicleCrateBlock.java
@@ -247,7 +247,7 @@ public class VehicleCrateBlock extends RotatedObjectBlock
         return stack;
     }
 
-    public static void registerVehicle(ResourceLocation id)
+    public static synchronized void registerVehicle(ResourceLocation id)
     {
         if(!REGISTERED_CRATES.contains(id))
         {

--- a/src/main/java/com/mrcrayfish/vehicle/client/EntityRayTracer.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/EntityRayTracer.java
@@ -169,7 +169,7 @@ public class EntityRayTracer
      * @param transforms the ray trace transforms for the vehicle
      * @param <T> an entity type that is a vehicle entity and implements IEntityRayTraceable
      */
-    public <T extends VehicleEntity & IEntityRayTraceable> void registerTransforms(EntityType<T> type, IRayTraceTransforms transforms)
+    public synchronized <T extends VehicleEntity & IEntityRayTraceable> void registerTransforms(EntityType<T> type, IRayTraceTransforms transforms)
     {
         this.entityRayTraceTransforms.putIfAbsent(type, transforms);
     }

--- a/src/main/java/com/mrcrayfish/vehicle/client/render/VehicleRenderRegistry.java
+++ b/src/main/java/com/mrcrayfish/vehicle/client/render/VehicleRenderRegistry.java
@@ -16,7 +16,7 @@ public final class VehicleRenderRegistry
     private static final Map<EntityType<?>, AbstractVehicleRenderer<?>> RENDERER_MAP = new HashMap<>();
     private static final Map<EntityType<?>, Function<VehicleProperties, ?>> RENDERER_FUNCTION_MAP = new HashMap<>();
 
-    public static void registerVehicleRendererFunction(EntityType<?> type, Function<VehicleProperties, ?> rendererFunction, AbstractVehicleRenderer<?> defaultRenderer)
+    public static synchronized void registerVehicleRendererFunction(EntityType<?> type, Function<VehicleProperties, ?> rendererFunction, AbstractVehicleRenderer<?> defaultRenderer)
     {
         RENDERER_FUNCTION_MAP.put(type, rendererFunction);
         RENDERER_MAP.put(type, defaultRenderer);

--- a/src/main/java/com/mrcrayfish/vehicle/common/VehicleRegistry.java
+++ b/src/main/java/com/mrcrayfish/vehicle/common/VehicleRegistry.java
@@ -25,7 +25,7 @@ public class VehicleRegistry
     private static final Map<ResourceLocation, IEngineType> ID_TO_ENGINE_TYPE = new HashMap<>();
     private static final Map<Pair<IEngineType, IEngineTier>, EngineItem> PAIR_TO_ENGINE_ITEM = new HashMap<>();
 
-    public static void registerVehicleType(EntityType<? extends VehicleEntity> entityType)
+    public static synchronized void registerVehicleType(EntityType<? extends VehicleEntity> entityType)
     {
         REGISTERED_VEHICLES.add(entityType);
     }
@@ -35,7 +35,7 @@ public class VehicleRegistry
         return REGISTERED_VEHICLES;
     }
 
-    public static void registerEngine(IEngineType type, IEngineTier tier, EngineItem item)
+    public static synchronized void registerEngine(IEngineType type, IEngineTier tier, EngineItem item)
     {
         Pair<IEngineType, IEngineTier> pair = Pair.of(type, tier);
         if(PAIR_TO_ENGINE_ITEM.containsKey(pair))


### PR DESCRIPTION
This PR fixes a critical issue with the current system for registering vehicles from other mods. By making methods synchronized, they will not cause issues for multithreaded mod loading.

This PR fixes:

- Concurrency issues when another mods tries to register vehicles, engines, or crates